### PR TITLE
Upload form fixes

### DIFF
--- a/application.py
+++ b/application.py
@@ -11,6 +11,7 @@ from werkzeug.utils import secure_filename
 
 EXTENSION = '.html'
 NUM_RESULTS = 4
+EMAIL_SUBJECT_FIELDS = ['name', 'zone', 'climber']
 
 # create the application object
 app = Flask(__name__)
@@ -116,15 +117,16 @@ def upload_file():
                                   for key, value in request.form.items()])
         video_data = video_data.replace('wt_embed_output', 'download link')
         # build email
-        msg = Message(subject="New Beta!",
-                      sender=app.config.get("MAIL_USERNAME"),
-                      recipients=app.config.get("MAIL_RECIPIENTS"),
-                      body=video_data)
+        msg = Message(
+            subject=(", ").join([request.form[field]
+                                 for field in EMAIL_SUBJECT_FIELDS]),
+            sender=app.config.get("MAIL_USERNAME"),
+            recipients=app.config.get("MAIL_RECIPIENTS"),
+            body=video_data)
         mail.send(msg)
         # TODO: show some sign of success
     return render_template(
         'upload.html',
-        uploading=False,
         locale=app.config["WE_TRANSFER_LOCALE_MAPPING"][get_locale()]
     )
 

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -145,7 +145,7 @@
                 &nbsp;
                 <li>
                   <a href="/language/ca?origin=upload" title="Catalan">
-                    {{ _("CatalÃ Â ") }}
+                    {{ _("Català ") }}
                   </a>
                 </li>
               </ul>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -73,6 +73,7 @@
               action="{{ url_for('upload_file') }}"
               method="POST"
               enctype="multipart/form-data"
+              onsubmit="return validateForm()"
             >
               <h4>{{_("Upload Form")}}</h4>
               <br />
@@ -144,7 +145,7 @@
                 &nbsp;
                 <li>
                   <a href="/language/ca?origin=upload" title="Catalan">
-                    {{ _("Català ") }}
+                    {{ _("CatalÃ Â ") }}
                   </a>
                 </li>
               </ul>
@@ -186,3 +187,13 @@
     box-sizing: border-box; /* Opera/IE 8+ */
   }
 </style>
+
+<script>
+  function validateForm() {
+    var form = document.forms["uploadForm"];
+    if (form["wt_embed_output"].value == "") {
+      alert("Please select a file or wait until the selected file has been uploaded");
+      return false;
+    }
+  }
+</script>


### PR DESCRIPTION
## Description of the issue/feature
Related issues: #56 #55 

## Current behavior
* Upload form can be submitted without an uploaded video
* Subject of the email when a new upload has been done provides little information

## Expected behavior after merge
* Upload form cannot be submitted without an uploaded video
* Email subject contained name of the climb, zone and climber. (instead of New Beta!)
* Grade field is now a text field
* Name and Zone are mandatory fields