### PR TITLE
Enable guide hosting

### DIFF
--- a/data/zones/taradell/taradell.txt
+++ b/data/zones/taradell/taradell.txt
@@ -8,6 +8,10 @@
     "sectors": [
     ],
     "guides":[
+        {
+            "name":"Guide",
+            "file":"taradell_guide.pdf"
+        }
     ],
     "playlist":"PLlwn5IhJiUnP1W9rHovE3XTbxQRCqpHVR"
 }

--- a/generate_pages.py
+++ b/generate_pages.py
@@ -1,6 +1,7 @@
 import os
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 import json
+import helpers
 
 def main():
     """
@@ -21,9 +22,16 @@ def main():
         with open(datafile, encoding='utf-8') as data:
             area_data = json.load(data)
 
+        # get external guide links
         guides = [(guide['name'], guide['link'])
-                  for guide in area_data['guides']]
+                  for guide in area_data['guides'] if guide.get('link')]
+        # get affiliate guides links 
         affiliate_guides = [affiliate_guide['link'] for affiliate_guide in area_data.get('affiliate_guides', [])]
+        # get hosted guides
+        hosted_guides = [(guide['name'], helpers.generate_download_url(area, guide['file']))
+                  for guide in area_data['guides'] if guide.get('file')]
+        # join guides
+        guides += hosted_guides
 
         base_url = "https://www.youtube.com/embed/?listType=playlist&list="
         playlists[area] = area_data['playlist']

--- a/helpers.py
+++ b/helpers.py
@@ -366,3 +366,7 @@ def get_number_of_videos_for_zone(zone_name):
     inp = urllib.request.urlopen(query_url)
     resp = json.load(inp)
     return resp['items'][0]['contentDetails']['itemCount']
+
+
+def generate_download_url(area, filename):
+    return '/download/' + area + '/' + filename

--- a/js_helpers.py
+++ b/js_helpers.py
@@ -62,14 +62,12 @@ def generate_sector_html(name, link):
     return '<p><b><u>{}</u></b><br><br><a href="{}" target="_blank">Beta videos</a><br></p>'.format(name, link)
 
 
-def generate_track_html(area, track_name):
+def generate_file_download_html(area, filename, text_to_show):
     """
-    Generate the html code that adds the link to the downloadable approximation
-    track
+    Generate the html code that adds the link to the downloadable file
     """
-    track_url = '/download/' + area + '/' + track_name
-    return '<a href="{}">Track</a><br>'.format(track_url)
-
+    download_url = '/download/' + area + '/' + filename
+    return '<a href="{}">{}</a><br>'.format(download_url, text_to_show)
 
 def make_layer_that_hides(map_html, map_name, layer_name, zoom_level=15, visible=True, reverse=False):
     """

--- a/js_helpers.py
+++ b/js_helpers.py
@@ -66,8 +66,7 @@ def generate_file_download_html(area, filename, text_to_show):
     """
     Generate the html code that adds the link to the downloadable file
     """
-    download_url = '/download/' + area + '/' + filename
-    return '<a href="{}">{}</a><br>'.format(download_url, text_to_show)
+    return '<a href="{}">{}</a><br>'.format(helpers.generate_download_url(area, filename), text_to_show)
 
 def make_layer_that_hides(map_html, map_name, layer_name, zoom_level=15, visible=True, reverse=False):
     """

--- a/load_map.py
+++ b/load_map.py
@@ -145,8 +145,8 @@ def load_map(area, datafile, generate_ids, return_html=True):
         )
         zone_approximation._id = generate_ids.next_id()  # reassign id
 
-        zone_approx_html = js_helpers.generate_track_html(
-            area, area_data.get('approximation'))
+        zone_approx_html = js_helpers.generate_file_download_html(
+            area, area_data.get('approximation'), 'Track')
 
         track_popup = folium.Popup(
             zone_approx_html,

--- a/templates/zones/taradell.html
+++ b/templates/zones/taradell.html
@@ -273,6 +273,19 @@ body {
   
   <ul>
     
+    <li>
+      <a
+        href="/download/taradell/taradell_guide.pdf"
+        target="_blank"
+        onclick="gtag('event', 'guide_click', {
+        'event_category': 'Taradell',
+        'event_label': '/download/taradell/taradell_guide.pdf'
+      });
+      "
+        >Guide</a
+      >
+    </li>
+    
   </ul>
 </div>
 </p>


### PR DESCRIPTION
This PR adds the additional field `"file"` to guides. See: 
https://github.com/MadBoulder/BetaLibrary/blob/3e5c8fdbf71cd6d97145d89edb80034897e4f8cc/data/zones/taradell/taradell.txt#L10-L15

If this field is included, a link - where the shown text will be the guide name - that enables the file download will be created. The downloadable file should be located inside the data folder of the area. (See https://github.com/MadBoulder/BetaLibrary/tree/enable-guide-hosting/data/zones/taradell for a reference).

In the case both `"file"` and `"link"` are provided two links will be created with the same name. One will download the file and the other redirect to the provided link.