### PR TITLE
Modify hosted guides format

### DIFF
--- a/application.py
+++ b/application.py
@@ -369,7 +369,7 @@ def download_file(path = None, filename = None):
         return send_from_directory(
             directory=download_path,
             filename=filename,
-            as_attachment=True
+            as_attachment=False
         )
     except:
         abort(404)

--- a/data/zones/taradell/taradell.txt
+++ b/data/zones/taradell/taradell.txt
@@ -10,7 +10,7 @@
     "guides":[
         {
             "name":"Guide",
-            "file":"taradell_guide.pdf"
+            "link":"https://madboulder.org/download/taradell/taradell_guide.pdf"
         }
     ],
     "playlist":"PLlwn5IhJiUnP1W9rHovE3XTbxQRCqpHVR"

--- a/generate_pages.py
+++ b/generate_pages.py
@@ -27,11 +27,6 @@ def main():
                   for guide in area_data['guides'] if guide.get('link')]
         # get affiliate guides links 
         affiliate_guides = [affiliate_guide['link'] for affiliate_guide in area_data.get('affiliate_guides', [])]
-        # get hosted guides
-        hosted_guides = [(guide['name'], helpers.generate_download_url(area, guide['file']))
-                  for guide in area_data['guides'] if guide.get('file')]
-        # join guides
-        guides += hosted_guides
 
         base_url = "https://www.youtube.com/embed/?listType=playlist&list="
         playlists[area] = area_data['playlist']

--- a/templates/zones/taradell.html
+++ b/templates/zones/taradell.html
@@ -275,11 +275,11 @@ body {
     
     <li>
       <a
-        href="/download/taradell/taradell_guide.pdf"
+        href="https://madboulder.org/download/taradell/taradell_guide.pdf"
         target="_blank"
         onclick="gtag('event', 'guide_click', {
         'event_category': 'Taradell',
-        'event_label': '/download/taradell/taradell_guide.pdf'
+        'event_label': 'https://madboulder.org/download/taradell/taradell_guide.pdf'
       });
       "
         >Guide</a


### PR DESCRIPTION
Store link instead of generating it from the filename. This keeps the guide's section and data more uniform, ordered and coherent.

The only think to keep in mind is that the link format for a guide hosted by us has to be:

`https://madboulder.org/download/AREA_NAME/FILE_NAME`

The file should be located inside the main data folder of a zone.

```
ZONE_NAME_FOLDER
     |_ sectors
     |_ zone_name.txt
     |_ file_to_download
```