### PR TITLE
Add options to limit stats shown to 50 results 

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -28,7 +28,7 @@ SORT_FUNCTION = """
                         sortedArray.push([i, jsObj[i][category]]);
                     }
                 }
-                // Run native sort function and returns sorted array.
+                // Run native sort function and return sorted array.
                 if (sort_method === 0) {
                     return sortedArray.sort();
                 }
@@ -40,7 +40,6 @@ SORT_FUNCTION = """
                 }
             }
 """
-
 
 def get_last_dashboard_update():
     return handle_channel_data.get_last_update_date()
@@ -110,21 +109,29 @@ def get_dashboard(local_data=False):
 
     # initial data source fill
     data_to_plot = barchart_data['grade']['raw']
+
     od = collections.OrderedDict(
         sorted(data_to_plot.items(), key=lambda x: x[0]))
 
-    x_to_plot = np.array([key for key, val in od.items()])
-    y_to_plot = np.array([val['count'] for key, val in od.items()])
+    x_to_plot = np.array([key for key, _ in od.items()])
+    y_to_plot = np.array([val['count'] for _, val in od.items()])
 
     source = ColumnDataSource(data=dict(x=x_to_plot, y=y_to_plot))
 
     # Create Input controls
+    checkbox_limit_results = CheckboxGroup(
+        labels=["Show only first 50 results"], active=[0])
+
     label_slider = Slider(start=0, end=90, value=90,
                           step=1, title="Label Angle")
+
     range_slider = RangeSlider(title="Value Range", start=0, end=max(
         y_to_plot), value=(0, max(y_to_plot)), step=1)
+
     min_year = Slider(title="From", start=2015, end=2020, value=2015, step=1)
+
     max_year = Slider(title="To", start=2015, end=2020, value=2020, step=1)
+
     sort_order = RadioButtonGroup(
         labels=[
             "Alphabetically",
@@ -135,24 +142,29 @@ def get_dashboard(local_data=False):
     )
     x_axis = Select(title="X Axis", options=sorted(
         x_axis_map.keys()), value="Grade")
+
     y_axis = Select(title="Y Axis", options=sorted(
         y_axis_map.keys()), value="Count")
+    
     checkbox = CheckboxGroup(
         labels=["Show ratio with respect to number of videos"], active=[])
 
     # show number of categories
     x_count_source = ColumnDataSource(
         data=dict(x_count=[len(x_to_plot)], category=[x_axis.value]))
+    
     columns = [
         TableColumn(field="category", title="Category"),
         TableColumn(field="x_count", title="Count"),
     ]
+    
     x_count_data_table = DataTable(
         source=x_count_source, columns=columns, width=320, height=280)
 
     # Generate the actual plot
     p = figure(x_range=x_to_plot, y_range=(0, max(y_to_plot)), plot_height=250, title="{} {}".format(x_axis.value, y_axis.value),
                toolbar_location="above")
+
     # Fill it with data and format it
     p.vbar(x='x', top='y', width=0.9, source=source)
     p.xaxis.major_label_orientation = math.pi/2
@@ -160,6 +172,7 @@ def get_dashboard(local_data=False):
 
     # Controls
     controls = [
+        checkbox_limit_results,
         range_slider,
         min_year,
         max_year,
@@ -194,10 +207,12 @@ def get_dashboard(local_data=False):
             y_axis_map=y_axis_map,
             y_axis=y_axis,
             range_slider=range_slider,
+            checkbox_limit_results=checkbox_limit_results,
             fig=p,
             title=p.title
         ),
         code=SORT_FUNCTION + """
+            const num_results = 50;
             var data = o_data[x_axis_map[x_axis.value]];
             var x = data['x'];
             var y = data['y'];
@@ -212,25 +227,45 @@ def get_dashboard(local_data=False):
             var new_y = [];
             var new_x = [];
             for (var i = 0; i < x.length; i++) {
-                if (sorted_data[i][1] >= range_slider.value[0] && sorted_data[i][1] <= range_slider.value[1]) {
+                if (checkbox_limit_results.active.length <= 0)
+                {
+                    if(sorted_data[i][1] >= range_slider.value[0] && sorted_data[i][1] <= range_slider.value[1]) 
+                    {
+                        new_x.push(sorted_data[i][0]);
+                        new_y.push(sorted_data[i][1]);
+                    } 
+                } else {
                     new_x.push(sorted_data[i][0]);
-                    new_y.push(sorted_data[i][1]);
+                    new_y.push(sorted_data[i][1]);                    
                 }
             }
-            x_source.data['x_count'] = [new_x.length];
+            if (checkbox_limit_results.active.length > 0) { 
+                final_x = new_x.slice(0, num_results);
+                final_y = new_y.slice(0, num_results);
+                window.should_update_range = false;
+            } else {
+                final_x = new_x;
+                final_y = new_y;
+                window.should_update_range = true;
+            }
+            x_source.data['x_count'] = [final_x.length];
             x_source.data['category'] = [x_axis.value];
             x_source.change.emit();
             source.data['x'] = new_x;
             source.data['y'] = new_y;
             source.change.emit();
             fig.x_range.factors = [];
-            fig.x_range.factors = new_x;
+            fig.x_range.factors = final_x;
             if (Array.isArray(new_y) && new_y.length) {
-                fig.y_range.end = Math.max.apply(Math, new_y);
+                range_slider.value = [0, Math.max.apply(Math, final_y)]; 
+                range_slider.end = Math.max.apply(Math, new_y);
+                fig.y_range.end = Math.max.apply(Math, final_y);
+                fig.change.emit();
             }
         """
     )
     checkbox.js_on_change('active', checkbox_callback)
+
     # range slider
     range_callback = CustomJS(
         args=dict(
@@ -243,37 +278,50 @@ def get_dashboard(local_data=False):
             y_axis_map=y_axis_map,
             y_axis=y_axis,
             checkbox=checkbox,
+            checkbox_limit_results=checkbox_limit_results,
             fig=p
         ),
         code=SORT_FUNCTION + """
-            var data = o_data[x_axis_map[x_axis.value]];
-            var x = data['x'];
-            var y = data['y'];
-            var is_ratio = checkbox.active.length > 0;
-            // Sort data
-            var sorted_data = sortData(data['raw'], sort_order.active, y_axis_map[y_axis.value], is_ratio);
-            var new_y = [];
-            var new_x = [];
-            for (var i = 0; i < x.length; i++) {
-                if (sorted_data[i][1] >= cb_obj.value[0] && sorted_data[i][1] <= cb_obj.value[1]) {
-                    new_x.push(sorted_data[i][0]);
-                    new_y.push(sorted_data[i][1]);
+            if (window.should_update_range == true) {
+                var data = o_data[x_axis_map[x_axis.value]];
+                var x = data['x'];
+                var y = data['y'];
+                var is_ratio = checkbox.active.length > 0;
+                // Sort data
+                var sorted_data = sortData(data['raw'], sort_order.active, y_axis_map[y_axis.value], is_ratio);
+                var new_y = [];
+                var new_x = [];
+                for (var i = 0; i < x.length; i++) {
+                    if (checkbox_limit_results.active.length <= 0)
+                    {
+                        if (sorted_data[i][1] >= cb_obj.value[0] && sorted_data[i][1] <= cb_obj.value[1]) 
+                        {
+                            new_x.push(sorted_data[i][0]);
+                            new_y.push(sorted_data[i][1]);
+                        }
+                    } else {
+                        new_x.push(sorted_data[i][0]);
+                        new_y.push(sorted_data[i][1]);                        
+                    }
                 }
-            }
-            x_source.data['x_count'] = [new_x.length];
-            x_source.data['category'] = [x_axis.value];
-            x_source.change.emit();
-            source.data['x'] = new_x;
-            source.data['y'] = new_y;
-            source.change.emit();
-            fig.x_range.factors = [];
-            fig.x_range.factors = new_x;
-            if (Array.isArray(new_y) && new_y.length) {
-                fig.y_range.end = Math.max.apply(Math, new_y);
+                x_source.data['x_count'] = [new_x.length];
+                x_source.data['category'] = [x_axis.value];
+                x_source.change.emit();
+                source.data['x'] = new_x;
+                source.data['y'] = new_y;
+                source.change.emit();
+                fig.x_range.factors = [];
+                fig.x_range.factors = new_x;
+                if (Array.isArray(new_y) && new_y.length) {
+                    fig.y_range.end = Math.max.apply(Math, new_y);
+                }
+            } else {
+                window.should_update_range = true;
             }
         """
     )
     range_slider.js_on_change('value', range_callback)
+
     # variable to group data
     x_axis_callback = CustomJS(
         args=dict(
@@ -286,10 +334,12 @@ def get_dashboard(local_data=False):
             range_slider=range_slider,
             sort_order=sort_order,
             checkbox=checkbox,
+            checkbox_limit_results=checkbox_limit_results,
             fig=p,
             title=p.title
         ),
         code=SORT_FUNCTION + """
+            const num_results = 50;
             title.text = cb_obj.value.concat(" ", y_axis.value);
             var data = o_data[x_axis_map[cb_obj.value]];
             var x = data['x'];
@@ -302,22 +352,34 @@ def get_dashboard(local_data=False):
             var sorted_data = sortData(data['raw'], sort_order.active, y_axis_map[y_axis.value], is_ratio);
             var new_y = [];
             var new_x = [];
+            var final_x = [];
+            var final_y = [];
             for (var i = 0; i < x.length; i++) {
                 new_x.push(sorted_data[i][0]);
                 new_y.push(sorted_data[i][1]);
             }
-            x_source.data['x_count'] = [new_x.length];
+            if (checkbox_limit_results.active.length > 0) {
+                final_x = new_x.slice(0, num_results);
+                final_y = new_y.slice(0, num_results);
+                window.should_update_range = false;
+            } else {
+                final_x = new_x;
+                final_y = new_y;
+                window.should_update_range = true;
+            }
+            x_source.data['x_count'] = [final_x.length];
             x_source.data['category'] = [cb_obj.value];
             x_source.change.emit();
             source.data['x'] = new_x;
             source.data['y'] = new_y;
             source.change.emit();
             fig.x_range.factors = [];
-            fig.x_range.factors = new_x;
+            fig.x_range.factors = final_x;
             if (new_y && Array.isArray(new_y) && new_y.length) {
-                range_slider.value = [0, Math.max.apply(Math, new_y)]; 
+                range_slider.value = [0, Math.max.apply(Math, final_y)]; 
                 range_slider.end = Math.max.apply(Math, new_y);
-                fig.y_range.end = Math.max.apply(Math, new_y);
+                fig.y_range.end = Math.max.apply(Math, final_y);
+                fig.change.emit();
             }
         """
     )
@@ -336,10 +398,12 @@ def get_dashboard(local_data=False):
             range_slider=range_slider,
             sort_order=sort_order,
             checkbox=checkbox,
+            checkbox_limit_results=checkbox_limit_results,
             fig=p,
             title=p.title
         ),
         code=SORT_FUNCTION + """
+            const num_results = 50;
             title.text = x_axis.value.concat(" ", cb_obj.value);
             var data = o_data[x_axis_map[x_axis.value]];
             var x = data['x'];
@@ -352,22 +416,33 @@ def get_dashboard(local_data=False):
             var sorted_data = sortData(data['raw'], sort_order.active, y_axis_map[cb_obj.value], is_ratio);
             var new_y = [];
             var new_x = [];
+            var final_x = [];
+            var final_y = [];
             for (var i = 0; i < x.length; i++) {
                 new_x.push(sorted_data[i][0]);
                 new_y.push(sorted_data[i][1]);
             }
-            x_source.data['x_count'] = [new_x.length];
+            if (checkbox_limit_results.active.length > 0) {
+                final_x = new_x.slice(0, num_results);
+                final_y = new_y.slice(0, num_results);
+                window.should_update_range = false;
+            } else {
+                final_x = new_x;
+                final_y = new_y;
+                window.should_update_range = true;
+            }
+            x_source.data['x_count'] = [final_x.length];
             x_source.data['category'] = [x_axis.value];
             x_source.change.emit();
             source.data['x'] = new_x;
             source.data['y'] = new_y;
             source.change.emit();
             fig.x_range.factors = [];
-            fig.x_range.factors = new_x;
+            fig.x_range.factors = final_x;
             if (new_y && Array.isArray(new_y) && new_y.length) {
-                range_slider.value = [0, Math.max.apply(Math, new_y)]; 
+                range_slider.value = [0, Math.max.apply(Math, final_y)]; 
                 range_slider.end = Math.max.apply(Math, new_y);
-                fig.y_range.end = Math.max.apply(Math, new_y);
+                fig.y_range.end = Math.max.apply(Math, final_y);
             }
         """
     )
@@ -386,34 +461,51 @@ def get_dashboard(local_data=False):
             y_axis=y_axis,
             range_slider=range_slider,
             checkbox=checkbox,
+            checkbox_limit_results=checkbox_limit_results,
             fig=p
         ),
         code=SORT_FUNCTION + """
+            const num_results = 50;
             var data = o_data[x_axis_map[x_axis.value]];
             var x = data['x'];
             var y = data['y'];
             // Sort data
             var is_ratio = checkbox.active.length > 0;
             var sorted_data = sortData(data['raw'], cb_obj.active, y_axis_map[y_axis.value], is_ratio);
-            console.log(sorted_data);
             var new_y = [];
             var new_x = [];
+            var final_x = [];
+            var final_y = [];
+            // push data if it lies inside range
             for (var i = 0; i < x.length; i++) {
-                if (sorted_data[i][1] >= range_slider.value[0] && sorted_data[i][1] <= range_slider.value[1]) {
+//                if (sorted_data[i][1] >= range_slider.value[0] && sorted_data[i][1] <= range_slider.value[1]) {
                     new_x.push(sorted_data[i][0]);
                     new_y.push(sorted_data[i][1]);
-                }
+//                }
             }
-            x_source.data['x_count'] = [new_x.length];
+            if (checkbox_limit_results.active.length > 0)
+            { 
+                final_x = new_x.slice(0, 50);
+                final_y = new_y.slice(0, 50);
+                window.should_update_range = false;
+            } else {
+                final_x = new_x;
+                final_y = new_y;
+                window.should_update_range = true;
+            }
+            x_source.data['x_count'] = [final_x.length];
             x_source.data['category'] = [x_axis.value];
             x_source.change.emit();
             source.data['x'] = new_x;
             source.data['y'] = new_y;
             source.change.emit();
             fig.x_range.factors = [];
-            fig.x_range.factors = new_x;
+            fig.x_range.factors = final_x;
             if (new_y && Array.isArray(new_y) && new_y.length) {
-                fig.y_range.end = Math.max.apply(Math, new_y);
+                range_slider.value = [0, Math.max.apply(Math, final_y)]; 
+                range_slider.end = Math.max.apply(Math, new_y);
+                fig.y_range.end = Math.max.apply(Math, final_y);
+                fig.change.emit();
             }
         """
     )

--- a/handle_channel_data.py
+++ b/handle_channel_data.py
@@ -244,7 +244,7 @@ def process_zone_data(infile=None, data=None):
     """
     video_data = load_data(infile, data)
     # regex to match zones.
-    zone_regex = r'(?:\.+.+)?(?:\. )(.+)$'
+    zone_regex = r'(?:\.+.+)?(?:\.\s* )(.+)$'
     video_data = match_regex_and_add_field(
         zone_regex, 'title', 'zone', video_data)
     for video in video_data:


### PR DESCRIPTION
Add a checkbox in the stats page that, when selected, limits results to 50.

A part from that, improve the regex for zone extraction from title and update processed channel data after this improvement.