### PR TITLE
Add state overview descriptions: templates, generator, routes, and ad…

### DIFF
--- a/application.py
+++ b/application.py
@@ -1498,17 +1498,21 @@ def add_state():
     try:
         data = request.get_json()
         countryCode = data['country']
-        stateCode = slugify(data['name'][0])
+        stateCode = data.get('state_code') or slugify(data['name'][0])
 
-        stateData = {
-            'name': data['name']
-        }
+        existingStateData = utils.MadBoulderDatabase.getStateData(countryCode, stateCode) or {}
+
+        stateData = dict(existingStateData)
+        if 'name' in data and data['name']:
+            stateData['name'] = data['name']
+        if 'overview' in data and data['overview'] is not None:
+            stateData['overview'] = data['overview']
 
         utils.MadBoulderDatabase.updateState(countryCode, stateCode, stateData)
-        return jsonify({'status': 'success', 'message': 'Country added successfully'}), 200
+        return jsonify({'status': 'success', 'message': 'State added/updated successfully'}), 200
     except Exception as e:
         print(f"An error occurred: {str(e)}")
-        return jsonify({'status': 'error', 'message': 'Failed to add country'}), 500
+        return jsonify({'status': 'error', 'message': 'Failed to add/update state'}), 500
     
 @app.route("/proxy/metadata")
 def proxy_metadata():
@@ -1957,7 +1961,22 @@ def load_country_es(country_name):
 @app.route('/templates/states/<string:state_name>.html')
 def load_state(state_name):
     try:
-        return render_template(f'states/{slugify(state_name)}.html')
+        language_extension = ''
+        if get_locale() == 'es':
+            language_extension = 'es/'
+
+        page_path = 'states/' + language_extension + slugify(state_name) + EXTENSION
+        return render_template(page_path)
+    except Exception as e:
+        print("An error occurred:", e)
+        abort(404)
+
+
+@app.route('/states/es/<string:state_name>')
+@app.route('/templates/states/es/<string:state_name>.html')
+def load_state_es(state_name):
+    try:
+        return render_template(f'states/es/{slugify(state_name)}.html')
     except Exception as e:
         print("An error occurred:", e)
         abort(404)

--- a/generate_country_pages.py
+++ b/generate_country_pages.py
@@ -13,6 +13,8 @@ def main():
     utils.helpers.empty_and_create_dir(dir_path_countries_es)
     dir_path_states = 'templates/states'
     utils.helpers.empty_and_create_dir(dir_path_states)
+    dir_path_states_es = 'templates/states/es'
+    utils.helpers.empty_and_create_dir(dir_path_states_es)
 
     country_data = utils.MadBoulderDatabase.getCountriesData()
     playlists = utils.MadBoulderDatabase.getPlaylistsData()
@@ -69,8 +71,12 @@ def main():
 
         for state_code, state in states.items():
             state_name = state.get("name", [""])[0]
+            state_name_es = state.get("name", ["", ""])[1] if len(state.get("name", [])) > 1 else state_name
+            state_overview = state.get("overview", ["", ""])
+            state_overview_en = state_overview[0] if len(state_overview) > 0 else ""
+            state_overview_es = state_overview[1] if len(state_overview) > 1 else ""
             print("generating state: " + state_code)
-            
+
             state_areas = utils.zone_helpers.get_areas_from_state(state_code, areasData)
             state_template = template_env.get_template('templates/templates/state_page_template.html')
             state_output = state_template.render(
@@ -79,11 +85,26 @@ def main():
                 state_code=state_code,
                 state_name=state_name,
                 areas=state_areas,
-                playlists=playlists
+                playlists=playlists,
+                overview=state_overview_en
             )
 
-            with open(f'templates/states/{state_code}.html', 'w', encoding='utf-8') as state_template:
-                state_template.write(state_output)
+            with open(f'templates/states/{state_code}.html', 'w', encoding='utf-8') as state_template_file:
+                state_template_file.write(state_output)
+
+            state_template_es = template_env.get_template('templates/templates/es/state_page_template.html')
+            state_output_es = state_template_es.render(
+                country_code=country_code,
+                country_name=country_name_es,
+                state_code=state_code,
+                state_name=state_name_es,
+                areas=state_areas,
+                playlists=playlists,
+                overview=state_overview_es
+            )
+
+            with open(f'templates/states/es/{state_code}.html', 'w', encoding='utf-8') as state_template_es_file:
+                state_template_es_file.write(state_output_es)
 
 if __name__ == '__main__':
     main()

--- a/templates/area-editor.html
+++ b/templates/area-editor.html
@@ -61,7 +61,7 @@
 							<select class="form-select" id="area-state">
 								<option value="">Select a state</option>
 							</select>
-							<button type="button" class="btn btn-outline-secondary btn-sm" onclick="addNewState();" style="white-space: nowrap;">
+							<button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#addStateModal" style="white-space: nowrap;">
 								+ New State
 							</button>
 						</div>
@@ -173,7 +173,7 @@
 									<label for="countryCode" >Reduced Code</label>
 									<input type="text" class="form-control" id="countryCode" required>
 								</div>
-								<div class="mb-3">	
+								<div class="mb-3">
 									<label for="countryOverviewEn">Overview (English)</label>
 									<textarea class="form-control" id="countryOverviewEn" rows="3" required></textarea>
 								</div>
@@ -182,6 +182,37 @@
 									<textarea class="form-control" id="countryOverviewEs" rows="3" required></textarea>
 								</div>
 								<button type="submit" class="btn btn-primary">Create New Country</button>
+							</form>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="modal fade" id="addStateModal" tabindex="-1" aria-labelledby="addStateModalLabel" aria-hidden="true">
+				<div class="modal-dialog">
+					<div class="modal-content">
+						<div class="modal-header">
+							<h5 class="modal-title" id="addStateModalLabel">Add New State</h5>
+							<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+						</div>
+						<div class="modal-body">
+							<form id="newStateForm">
+								<div class="mb-3">
+									<label for="stateNameEn">State Name (English)</label>
+									<input type="text" class="form-control" id="stateNameEn" required>
+								</div>
+								<div class="mb-3">
+									<label for="stateNameEs">State Name (Spanish)</label>
+									<input type="text" class="form-control" id="stateNameEs" required>
+								</div>
+								<div class="mb-3">
+									<label for="stateOverviewEn">Overview (English)</label>
+									<textarea class="form-control" id="stateOverviewEn" rows="3"></textarea>
+								</div>
+								<div class="mb-3">
+									<label for="stateOverviewEs">Overview (Spanish)</label>
+									<textarea class="form-control" id="stateOverviewEs" rows="3"></textarea>
+								</div>
+								<button type="submit" class="btn btn-primary">Create New State</button>
 							</form>
 						</div>
 					</div>
@@ -393,40 +424,55 @@
 					});
 				});
 
-				function addNewState() {
+				document.getElementById('addStateModal').addEventListener('show.bs.modal', function(event) {
+					var selectedCountry = document.getElementById('country-select').value;
+					if (!selectedCountry) {
+						alert("Please select a country first.");
+						event.preventDefault();
+						bootstrap.Modal.getInstance(document.getElementById('addStateModal'))?.hide();
+						return false;
+					}
+				});
+
+				document.getElementById('newStateForm').addEventListener('submit', function(event) {
+					event.preventDefault();
+
 					var selectedCountry = document.getElementById('country-select').value;
 					if (!selectedCountry) {
 						alert("Please select a country first.");
 						return;
 					}
 
-					var newStateNameEn = prompt("Enter new state name (English):");
-					var newStateNameEs = prompt("Enter new state name (Spanish):");
+					const stateNameEn = document.getElementById('stateNameEn').value;
+					const stateNameEs = document.getElementById('stateNameEs').value;
+					const stateOverviewEn = document.getElementById('stateOverviewEn').value;
+					const stateOverviewEs = document.getElementById('stateOverviewEs').value;
 
-					if (newStateNameEn) {
-						const newStateData = {
-							country: selectedCountry,
-							name: [newStateNameEn, newStateNameEs]
-						};
+					const newStateData = {
+						country: selectedCountry,
+						name: [stateNameEn, stateNameEs],
+						overview: [stateOverviewEn, stateOverviewEs]
+					};
 
-						fetch('/add-state', {
-							method: 'POST',
-							headers: {
+					fetch('/add-state', {
+						method: 'POST',
+						headers: {
 							'Content-Type': 'application/json',
-							},
-							body: JSON.stringify(newStateData)
-						})
-						.then(response => response.json())
-						.then(data => {
-							console.log('Success:', data);
-							alert('State added successfully!');
-							fetchCountries()
-						})
-						.catch((error) => {
-							console.error('Error:', error);
-						});
-					}
-				}
+						},
+						body: JSON.stringify(newStateData)
+					})
+					.then(response => response.json())
+					.then(data => {
+						console.log('Success:', data);
+						$('#addStateModal').modal('hide');
+						alert('State added successfully!');
+						document.getElementById('newStateForm').reset();
+						fetchCountries();
+					})
+					.catch((error) => {
+						console.error('Error:', error);
+					});
+				});
 
 				var areaMap, parkingMap;
 				var areaMarker, parkingMarkers = [];

--- a/templates/templates/es/state_page_template.html
+++ b/templates/templates/es/state_page_template.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
   <head>
-    <title>{% raw %}{{ _("Bouldering Areas in") }}{% endraw %} {{ state_name }}, {{ country_name }} | MadBoulder</title>
-	<meta name="description" content="List of Bouldering Areas in {{ state_name }}, {{ country_name }} | MadBoulder">
-	<link rel="canonical" href="https://www.madboulder.org/states/{{state_code}}">
+    <title>Zonas de Boulder en {{ state_name }}, {{ country_name }} | MadBoulder</title>
+	<meta name="description" content="Lista de Zonas de Boulder en {{ state_name }}, {{ country_name }} | MadBoulder">
+	<link rel="canonical" href="https://www.madboulder.org/states/es/{{state_code}}">
 	<link rel="alternate" hreflang="en" href="https://www.madboulder.org/states/{{state_code}}">
 	<link rel="alternate" hreflang="es" href="https://www.madboulder.org/states/es/{{state_code}}">
 	{% raw %}
@@ -31,12 +31,12 @@
 			<div class="container">
 				<nav aria-label="breadcrumb">
 					<ol class="mb-breadcrumb">
-						<li><a href="/bouldering-areas-list">{% raw %}{{ _("All Areas") }}{% endraw %}</a></li>
-						<li><a href="/countries/{{country_code}}">{{ country_name }}</a></li>
+						<li><a href="/bouldering-areas-list">Todas las Zonas</a></li>
+						<li><a href="/countries/es/{{country_code}}">{{ country_name }}</a></li>
 					</ol>
 				</nav>
 				<h1 class="mb-section-header-title">
-					{{ areas|length }} Bouldering Areas in {{ state_name }}, {{ country_name }}
+					{{ areas|length }} Zonas de Boulder en {{ state_name }}, {{ country_name }}
 				</h1>
 			</div>
 		</div>
@@ -54,14 +54,14 @@
 			</div>
 			{% if overview %}
 			<div class="container">
-				<h2>Bouldering in {{ state_name }}</h2>
+				<h2>Boulder en {{ state_name }}</h2>
 				<p class="country-overview" id="overview">
 					{{ overview }}
 				</p>
 				<div class="ellipsis-container">
 					<span class="ellipsis" id="ellipsis">...</span>
 				</div>
-				<p id="showMoreLink" class="show-more-trigger" onclick="toggleShowMore()">Show more</p>
+				<p id="showMoreLink" class="show-more-trigger" onclick="toggleShowMore()">Read more</p>
 				<script>
 					document.addEventListener("DOMContentLoaded", function() {
 						var content = document.getElementById("overview");
@@ -105,7 +105,7 @@
 				</script>
 			</div>
 			{% endif %}
-			<h2 class="mb-mb-4">{% raw %} {{ _("List of Areas") }} {% endraw %}</h2>
+			<h2 class="mb-mb-4">Lista de Zonas</h2>
 			{% raw %}
 			{% set show_video_filter = True %}
 			{% set show_country_filter = False %}


### PR DESCRIPTION

- Add overview section to EN/ES state page templates with collapsible show more/less
- Create ES state page template (templates/templates/es/state_page_template.html)
- Update generate_country_pages.py to generate EN + ES state pages with overview
- Add /states/es/<state_name> route and locale-aware state page serving
- Extend /add-state endpoint to accept optional overview field (upsert pattern)
- Replace prompt-based state creation with modal form in area-editor (with overview fields)

Closes #228